### PR TITLE
Add connection metrics per username

### DIFF
--- a/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
+++ b/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
@@ -89,7 +89,7 @@ public class NotificationWebSocketIT {
 
     private void testMeterMap(Map<String, Double> userMap) {
         for (Map.Entry<String, Double> userEntry : userMap.entrySet()) {
-            assertEquals(userEntry.getValue(), meterRegistry.get(USERS_METER_NAME).tag(USER_TAG, userEntry.getKey()).gauge().value(), 1e-6);
+            assertEquals(userEntry.getValue(), meterRegistry.get(USERS_METER_NAME).tag(USER_TAG, userEntry.getKey()).gauge().value(), 0);
         }
     }
 }


### PR DESCRIPTION
Use multigauge to handle connection metrics per username.  

From micrometer documentation, the multigauge is the best fit for this use:
`Micrometer supports one last special type of Gauge, called a MultiGauge, to help manage gauging a growing or shrinking list of criteria. `
Source: https://docs.micrometer.io/micrometer/reference/concepts/gauges.html