### PR TITLE
Fix user metrics

### DIFF
--- a/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
+++ b/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
@@ -21,8 +21,10 @@ import org.springframework.web.reactive.socket.client.WebSocketClient;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.gridsuite.study.notification.server.NotificationWebSocketHandler.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Jon Harper <jon.harper at rte-france.com>
@@ -50,44 +52,20 @@ public class NotificationWebSocketIT {
     protected URI getUrl(String path) {
         return URI.create("ws://localhost:" + this.port + path);
     }
-// FIXME: disabled tests because they are not reproducible on github action
-//    @Test
-//    public void metricsMapOneUserTwoConnections() {
-//        WebSocketClient client1 = new StandardWebSocketClient();
-//        HttpHeaders httpHeaders1 = new HttpHeaders();
-//        String user = "test";
-//        httpHeaders1.add(HEADER_USER_ID, user);
-//        Map<String, Double> exp = Map.of(user, 2d);
-//        Mono<Void> connection1 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> testMeterMap(exp)));
-//        Mono<Void> connection2 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> testMeterMap(exp)));
-//
-//        Mono.zip(connection1, connection2).block();
-//    }
-//
-//    @Test
-//    public void metricsMapTwoUsers() {
-//        // First WebSocketClient for connections related to 'test' user
-//        WebSocketClient client1 = new StandardWebSocketClient();
-//        HttpHeaders httpHeaders1 = new HttpHeaders();
-//        String user1 = "test";
-//        httpHeaders1.add(HEADER_USER_ID, user1);
-//        String user2 = "test1";
-//        Map<String, Double> exp = Map.of(user1, 2d, user2, 1d);
-//        Mono<Void> connection1 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> testMeterMap(exp)));
-//        Mono<Void> connection2 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> testMeterMap(exp)));
-//
-//        // Second WebSocketClient for connections related to 'test1' user
-//        WebSocketClient client2 = new StandardWebSocketClient();
-//        HttpHeaders httpHeaders2 = new HttpHeaders();
-//        httpHeaders2.add(HEADER_USER_ID, user2);
-//        Mono<Void> connection3 = client2.execute(getUrl("/notify"), httpHeaders2, ws -> Mono.fromRunnable(() -> testMeterMap(exp)));
-//
-//        Mono.zip(connection1, connection2, connection3).block();
-//    }
-//
-//    private void testMeterMap(Map<String, Double> userMap) {
-//        for (Map.Entry<String, Double> userEntry : userMap.entrySet()) {
-//            assertEquals(userEntry.getValue(), meterRegistry.get(USERS_METER_NAME).tag(USER_TAG, userEntry.getKey()).gauge().value(), 0);
-//        }
-//    }
+
+    @Test
+    public void metricsMapOneUser() {
+        WebSocketClient client1 = new StandardWebSocketClient();
+        HttpHeaders httpHeaders1 = new HttpHeaders();
+        String user = "test";
+        httpHeaders1.add(HEADER_USER_ID, user);
+        Map<String, Double> exp = Map.of(user, 1d);
+        client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> testMeterMap(exp))).block();
+    }
+
+    private void testMeterMap(Map<String, Double> userMap) {
+        for (Map.Entry<String, Double> userEntry : userMap.entrySet()) {
+            assertEquals(userEntry.getValue(), meterRegistry.get(USERS_METER_NAME).tag(USER_TAG, userEntry.getKey()).gauge().value(), 0);
+        }
+    }
 }


### PR DESCRIPTION
* Register only once the meterRegistry to correctly update the gauge when userConnections map is updated. 
* Fix concurrency issues in tests