### PR TITLE
Add delay between connections to improve robustness

### DIFF
--- a/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
+++ b/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -66,8 +67,8 @@ public class NotificationWebSocketIT {
         CountDownLatch connectionLatch = new CountDownLatch(2);
         CountDownLatch assertLatch = new CountDownLatch(1);
 
-        Mono<Void> connection1 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic());
-        Mono<Void> connection2 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic());
+        Mono<Void> connection1 = Mono.delay(Duration.ofMillis(100)).then(client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic()));
+        Mono<Void> connection2 = Mono.delay(Duration.ofMillis(200)).then(client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic()));
 
         CompletableFuture<Void> evaluationFuture = evaluateAssert(connectionLatch, exp, assertLatch);
         Mono.zip(connection1, connection2).block();
@@ -85,14 +86,14 @@ public class NotificationWebSocketIT {
         Map<String, Double> exp = Map.of(user1, 2d, user2, 1d);
         CountDownLatch connectionLatch = new CountDownLatch(3);
         CountDownLatch assertLatch = new CountDownLatch(1);
-        Mono<Void> connection1 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic());
-        Mono<Void> connection2 = client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic());
+        Mono<Void> connection1 = Mono.delay(Duration.ofMillis(100)).then(client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic()));
+        Mono<Void> connection2 = Mono.delay(Duration.ofMillis(200)).then(client1.execute(getUrl("/notify"), httpHeaders1, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic()));
 
         // Second WebSocketClient for connections related to 'test1' user
         WebSocketClient client2 = new StandardWebSocketClient();
         HttpHeaders httpHeaders2 = new HttpHeaders();
         httpHeaders2.add(HEADER_USER_ID, user2);
-        Mono<Void> connection3 = client2.execute(getUrl("/notify"), httpHeaders2, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic());
+        Mono<Void> connection3 = Mono.delay(Duration.ofMillis(300)).then(client2.execute(getUrl("/notify"), httpHeaders2, ws -> Mono.fromRunnable(() -> handleLatches(connectionLatch, assertLatch))).subscribeOn(Schedulers.boundedElastic()));
 
         CompletableFuture<Void> evaluationFuture = evaluateAssert(connectionLatch, exp, assertLatch);
         Mono.zip(connection1, connection2, connection3).block();


### PR DESCRIPTION
In order for the meterRegistry to be updated correctly in the test, add a delay (here 100ms) between each connection. 
This should fix the stability issue of these 2 tests that fail from time to time.