### PR TITLE
Disable unstable tests

### DIFF
--- a/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
+++ b/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java
@@ -7,6 +7,7 @@
 package org.gridsuite.study.notification.server;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +58,7 @@ public class NotificationWebSocketIT {
     }
 
     @Test
+    @Ignore("This test case is not stable due to unexpected behavior of meterRegistry in asynchronous test context")
     public void metricsMapOneUserTwoConnections() {
         WebSocketClient client1 = new StandardWebSocketClient();
         HttpHeaders httpHeaders1 = new HttpHeaders();
@@ -75,6 +77,7 @@ public class NotificationWebSocketIT {
     }
 
     @Test
+    @Ignore("This test case is not stable due to unexpected behavior of meterRegistry in asynchronous test context")
     public void metricsMapTwoUsers() {
         // First WebSocketClient for connections related to 'test' user
         WebSocketClient client1 = new StandardWebSocketClient();


### PR DESCRIPTION
Disable unstable tests that randomly fails the CI. It seems to be due to an unexpected behavior of meterRegistry in asynchronous test context. 
These tests could also be refactored using Mono or Flux API instead of trying to workaround with manual CountDownLatch. 
This behavior was already observed with the previous implementation: https://github.com/gridsuite/study-notification-server/blob/2a104641beb960d53a516e1a4640b249cc4fadac/src/test/java/org/gridsuite/study/notification/server/NotificationWebSocketIT.java